### PR TITLE
swingset: install latest

### DIFF
--- a/README-gallery-demo.md
+++ b/README-gallery-demo.md
@@ -7,12 +7,12 @@ pixels.
 
 To access the gallery, type `home.gallery` in the REPL. `home.gallery` is a
 Presence. In the SwingSet environment, Presences are remote references to objects on
-other vats. To invoke them, use the `E` wrapper. For example, the
+other vats. To invoke them, use the [proposed infix bang](https://github.com/Agoric/proposal-infix-bang). For example, the
 first thing you might want to do is tap the gallery faucet to get a
 pixel for free: 
 
 ```js
-E(home.gallery).tapFaucet()
+home.gallery!tapFaucet()
 ```
 
 This returns a presence for the pixel that you receive from the
@@ -28,23 +28,22 @@ using the 'use' right, and selling a pixel to the gallery through a
 escrow smart contract.  
 
 ```
-E(home.gallery).tapFaucet()
-E(home.gallery).split(history[0])
+home.gallery!tapFaucet()
+home.gallery!split(history[0])
 history[1].useRightPayment
-E(home.gallery).changeColor(history[2], '#FF69B4')
-E(home.gallery).tapFaucet()
-E(history[4]).getBalance()
-E(home.gallery).pricePixelAmount(history[5])
-E(home.gallery).sellToGallery(history[5])
+home.gallery!changeColor(history[2], '#FF69B4')
+home.gallery!tapFaucet()
+history[4]!getBalance()
+home.gallery!pricePixelAmount(history[5])
+home.gallery!sellToGallery(history[5])
 history[7].inviteP
 history[7].host
-E(history[9]).redeem(history[8])
-E(history[10]).offer(history[4])
-E(home.gallery).getIssuers()
+history[9]!redeem(history[8])
+history[10]!offer(history[4])
+home.gallery!getIssuers()
 history[12].pixelIssuer
 history[12].dustIssuer
-E(history[13]).makeEmptyPurse()
-E(history[14]).makeEmptyPurse()
-E(home.gallery).collectFromGallery(history[10], history[16],
-history[15], 'my escrow')
+history[13]!makeEmptyPurse()
+history[14]!makeEmptyPurse()
+home.gallery!collectFromGallery(history[10], history[16], history[15], 'my escrow')
 ```

--- a/lib/ag-solo/start.js
+++ b/lib/ag-solo/start.js
@@ -4,8 +4,9 @@ import process from 'process';
 // import { createHash } from 'crypto';
 
 // import connect from 'lotion-connect';
-import harden from '@agoric/harden';
+// import harden from '@agoric/harden';
 // import djson from 'deterministic-json';
+// import maybeExtendPromise from '@agoric/transform-bang';
 
 import {
   loadBasedir,
@@ -24,6 +25,8 @@ import { connectToChain } from './chain-cosmos-sdk';
 
 // import { makeChainFollower } from './follower';
 // import { makeDeliverator } from './deliver-with-ag-cosmos-helper';
+
+console.log('Promise.makeHandled', typeof Promise.makeHandled, typeof Promise.prototype.get);
 
 async function buildSwingset(stateFile, withSES, vatsDir, argv) {
   const state = JSON.parse(fs.readFileSync(stateFile));

--- a/lib/ag-solo/vats/repl.js
+++ b/lib/ag-solo/vats/repl.js
@@ -88,7 +88,10 @@ export function getReplHandler(E, homeObjects, sendBroadcast) {
       highestHistory = histnum;
 
       commands[histnum] = body;
-      display[histnum] = `working on eval(${body})`;
+
+      // Need this concatenation to bypass direct eval test in realms-shim.
+      // eslint-disable-next-line no-useless-concat
+      display[histnum] = `working on eval` + `(${body})`;
       updateHistorySlot(histnum);
 
       const endowments = { console, E, commands, history, home: homeObjects };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,32 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@agoric/ertp": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@agoric/ertp/-/ertp-0.0.7.tgz",
-      "integrity": "sha512-pzkqvmgudndvUeqyu/EcStIl4JEV3BrwWBOv+jNhXK0epbtlFOIhPOGlwrBA91CdNQ3roID8mgnGbE33mdBk5w==",
+    "@agoric/acorn-infix-bang": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@agoric/acorn-infix-bang/-/acorn-infix-bang-0.0.4.tgz",
+      "integrity": "sha512-hbNRcyYddtcCPb0j2KyPRwdQ/avzH45TW0KlwiGbHINeDses5lcP4nvaqmA5aMNKp1RtWzD+280sYtzBTy8kng==",
       "requires": {
-        "@agoric/evaluate": "file:node_modules/@agoric/ertp/node_modules/@agoric/ertp/node_modules/@agoric/ertp/agoric-evaluate-0.0.1.tgz",
+        "acorn": "^6.2.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+          "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw=="
+        }
+      }
+    },
+    "@agoric/babel-parser": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@agoric/babel-parser/-/babel-parser-7.5.0.tgz",
+      "integrity": "sha512-lWAVssRdJBK1Rr7lndOdJ24qaG/r8dIY43oUFumQr0FW9f4oID2WZoBlX7pDBdwZXHIHIvYa+p09q5obYBoROw=="
+    },
+    "@agoric/ertp": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@agoric/ertp/-/ertp-0.0.8.tgz",
+      "integrity": "sha512-fA7/drHyRStfPZoqN1XDkTl2i28msW4Jr9viVtIhNsO/MLfYMm1Vq1WR2hSdFw7WTbyFHfJi/Z/Zf34ATZG/sA==",
+      "requires": {
+        "@agoric/evaluate": "file:node_modules/@agoric/ertp/agoric-evaluate-0.0.1.tgz",
         "@agoric/harden": "0.0.4",
         "@agoric/marshal": "0.0.1",
         "@agoric/nat": "^2.0.1",
@@ -18,7 +38,7 @@
       },
       "dependencies": {
         "@agoric/evaluate": {
-          "version": "file:node_modules/@agoric/ertp/node_modules/@agoric/ertp/node_modules/@agoric/ertp/agoric-evaluate-0.0.1.tgz",
+          "version": "file:node_modules/@agoric/ertp/agoric-evaluate-0.0.1.tgz",
           "bundled": true
         },
         "@agoric/swingset-vat": {
@@ -26,7 +46,7 @@
           "resolved": "https://registry.npmjs.org/@agoric/swingset-vat/-/swingset-vat-0.0.12.tgz",
           "integrity": "sha512-YZR0gvSvN5T6GcB82omvJKZ6+9OCbv9HpKmmGHtl8HJ6YtkElmYqQDr9qZTIoZvaIkdHj4DLlY97C6sjxfcMjw==",
           "requires": {
-            "@agoric/evaluate": "file:node_modules/@agoric/ertp/node_modules/@agoric/swingset-vat/node_modules/@agoric/ertp/node_modules/@agoric/swingset-vat/node_modules/@agoric/ertp/node_modules/@agoric/swingset-vat/agoric-evaluate/agoric-evaluate-0.0.1.tgz",
+            "@agoric/evaluate": "file:node_modules/@agoric/ertp/node_modules/@agoric/swingset-vat/agoric-evaluate/agoric-evaluate-0.0.1.tgz",
             "@agoric/harden": "^0.0.4",
             "@agoric/marshal": "0.0.1",
             "@agoric/nat": "^2.0.0",
@@ -38,7 +58,7 @@
           },
           "dependencies": {
             "@agoric/evaluate": {
-              "version": "file:node_modules/@agoric/ertp/node_modules/@agoric/swingset-vat/node_modules/@agoric/ertp/node_modules/@agoric/swingset-vat/node_modules/@agoric/ertp/node_modules/@agoric/swingset-vat/agoric-evaluate/agoric-evaluate-0.0.1.tgz",
+              "version": "file:node_modules/@agoric/ertp/node_modules/@agoric/swingset-vat/agoric-evaluate/agoric-evaluate-0.0.1.tgz",
               "bundled": true
             }
           }
@@ -48,6 +68,11 @@
     "@agoric/evaluate": {
       "version": "file:agoric-evaluate-0.0.1.tgz",
       "integrity": "sha512-/AJ0tlyunJgq66DIJ9uoCiCqVksRiYxD/2UmbjXavki1TG8q7iFcklmNLnq3li26BZNhbZehodyIlEJKrACaTg=="
+    },
+    "@agoric/eventual-send": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.1.10.tgz",
+      "integrity": "sha512-g1lmfayl28twcK8kB0VktRzk9x8g6YG2uwftFluYYfmomBdrO4DdOQzM0BoEeQquvzETBz+9d1bzfHbw9ZAGUg=="
     },
     "@agoric/harden": {
       "version": "0.0.4",
@@ -70,6 +95,22 @@
         "@agoric/harden": "0.0.4",
         "@agoric/nat": "^2.0.1",
         "ses": "^0.5.0"
+      },
+      "dependencies": {
+        "@agoric/make-hardener": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/@agoric/make-hardener/-/make-hardener-0.0.6.tgz",
+          "integrity": "sha512-OpZcNx/7bhHar0iuQ6D+FKYCMMxqKvYs4aC/bB5v/ffZaSM5sNAl98DnGL1mD9NSyZLGzAZ7D5XwJpe37BMldQ=="
+        },
+        "ses": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/ses/-/ses-0.5.2.tgz",
+          "integrity": "sha512-09pHZlxE+d14vVBCGpcaRlWIyFxf6Fyvrc7VkmX1W5GaR6LmjdHJpUixK05Ciu9fOOj6m1js5AFjSkVh/LZ6RA==",
+          "requires": {
+            "@agoric/make-hardener": "^0.0.6",
+            "esm": "^3.2.25"
+          }
+        }
       }
     },
     "@agoric/nat": {
@@ -78,25 +119,54 @@
       "integrity": "sha512-puvWkoaJovQib/YaSRSGJ8Kn9rogi/yyaVa3d5znSZb5WiYfUiEKW35BfexHhAdi0VfPz2anFHoRBoBSUIijNA=="
     },
     "@agoric/swingset-vat": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@agoric/swingset-vat/-/swingset-vat-0.0.14.tgz",
-      "integrity": "sha512-s6f6YAaQP1sOJjdUdb/pVcne2mM3Q5flevGuy8iH3iZBBMwttFkevIN2FucIyscM3iy5IUj3aH+DWekCWyMCkw==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@agoric/swingset-vat/-/swingset-vat-0.0.15.tgz",
+      "integrity": "sha512-xeOqtlAIL1WN0+oM0Krt9fovyV92Bc9BZnxMywOI4Ugkjd4w2FVi82hThFIDGInP9jC8Vnpa05WZh2d9pIDmbQ==",
       "requires": {
-        "@agoric/evaluate": "file:node_modules/@agoric/swingset-vat/node_modules/@agoric/swingset-vat/node_modules/@agoric/swingset-vat/agoric-evaluate/agoric-evaluate-0.0.1.tgz",
+        "@agoric/acorn-infix-bang": "0.0.4",
+        "@agoric/babel-parser": "^7.5.0-infixBang.1",
+        "@agoric/evaluate": "file:node_modules/@agoric/swingset-vat/agoric-evaluate/agoric-evaluate-0.0.1.tgz",
+        "@agoric/eventual-send": "^0.1.9",
         "@agoric/harden": "^0.0.4",
         "@agoric/marshal": "0.0.1",
         "@agoric/nat": "^2.0.0",
-        "rollup": "^1.1.2",
+        "@agoric/transform-bang": "^0.3.1",
+        "@babel/generator": "^7.5.0",
+        "babel-plugin-syntax-infix-bang": "^7.4.5",
+        "rollup": "^1.16.7",
         "rollup-plugin-node-resolve": "^5.0.1",
         "semver": "^6.1.0",
-        "ses": "^0.5.0",
+        "ses": "^0.5.1",
         "yargs": "^13.1.0"
       },
       "dependencies": {
         "@agoric/evaluate": {
-          "version": "file:node_modules/@agoric/swingset-vat/node_modules/@agoric/swingset-vat/node_modules/@agoric/swingset-vat/agoric-evaluate/agoric-evaluate-0.0.1.tgz",
+          "version": "file:node_modules/@agoric/swingset-vat/agoric-evaluate/agoric-evaluate-0.0.1.tgz",
           "bundled": true
+        },
+        "@agoric/make-hardener": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/@agoric/make-hardener/-/make-hardener-0.0.6.tgz",
+          "integrity": "sha512-OpZcNx/7bhHar0iuQ6D+FKYCMMxqKvYs4aC/bB5v/ffZaSM5sNAl98DnGL1mD9NSyZLGzAZ7D5XwJpe37BMldQ=="
+        },
+        "ses": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/ses/-/ses-0.5.2.tgz",
+          "integrity": "sha512-09pHZlxE+d14vVBCGpcaRlWIyFxf6Fyvrc7VkmX1W5GaR6LmjdHJpUixK05Ciu9fOOj6m1js5AFjSkVh/LZ6RA==",
+          "requires": {
+            "@agoric/make-hardener": "^0.0.6",
+            "esm": "^3.2.25"
+          }
         }
+      }
+    },
+    "@agoric/transform-bang": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@agoric/transform-bang/-/transform-bang-0.3.1.tgz",
+      "integrity": "sha512-Qhbf71pM3n/o/VSmsL38n9Yk8P0BTi+/UuXbySo9hmzWTLofHeUU1luI/CrRUtz6z6Fqt5JvAhiMIxcJdAthsg==",
+      "requires": {
+        "@agoric/harden": "0.0.4",
+        "esm": "^3.2.5"
       }
     },
     "@babel/code-frame": {
@@ -108,6 +178,23 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/generator": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
+      "integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
+      "requires": {
+        "@babel/types": "^7.5.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.11",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+    },
     "@babel/highlight": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -117,6 +204,16 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
+      "integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.11",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@iarna/toml": {
@@ -130,9 +227,9 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/node": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
-      "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg=="
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.2.tgz",
+      "integrity": "sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ=="
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -260,6 +357,14 @@
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7"
+      }
+    },
+    "babel-plugin-syntax-infix-bang": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-infix-bang/-/babel-plugin-syntax-infix-bang-7.4.5.tgz",
+      "integrity": "sha512-t/cbQglQKM9tF+RQ8OQQI4dG3YUSVpVDRCpeaNGMzj9o44Dx6m/gx6350PDpNCRN57ZLDbG7oZl6QErtAIVopQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "balanced-match": {
@@ -1049,8 +1154,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -1582,6 +1686,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1716,8 +1825,7 @@
     "lodash": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -2569,6 +2677,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
       "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -2617,25 +2726,35 @@
       }
     },
     "rollup": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.15.6.tgz",
-      "integrity": "sha512-s3Vn3QJQ5YVFfIG4nXoG9VdL1I37IZsft+4ZyeBhxE0df1kCFz9e+4bEAbR4mKH3pvBO9e9xjdxWPhhIp0r9ow==",
+      "version": "1.16.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.16.7.tgz",
+      "integrity": "sha512-P3GVcbVSLLjHWFLKGerYRe3Q/yggRXmTZFx/4WZf4wzGwO6hAg5jyMAFMQKc0dts8rFID4BQngfoz6yQbI7iMQ==",
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^12.0.8",
+        "@types/node": "^12.0.10",
         "acorn": "^6.1.1"
       }
     },
     "rollup-plugin-node-resolve": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.3.tgz",
-      "integrity": "sha512-Mhhmf0x493xgUPEsRELnU1VM+4+WO82knWkAbZ0d2DvZQZJMbhzyQK/hqtpVscoRru1EqlK3TM1kK9ro469wPw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
+      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
       "requires": {
         "@types/resolve": "0.0.8",
         "builtin-modules": "^3.1.0",
         "is-module": "^1.0.0",
-        "resolve": "^1.11.0",
-        "rollup-pluginutils": "^2.8.0"
+        "resolve": "^1.11.1",
+        "rollup-pluginutils": "^2.8.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "rollup-pluginutils": {
@@ -2680,9 +2799,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-      "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+      "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
     },
     "send": {
       "version": "0.17.1",
@@ -2723,12 +2842,19 @@
       }
     },
     "ses": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ses/-/ses-0.5.0.tgz",
-      "integrity": "sha512-alpPOmwrlOhg52o2ix7ZaXMCqhQ7MrZ4AR+BZSB2VmiFJ8u5L9sRIZGkfmom0Dexal6RXvNUJkx81QwXVQx9Kg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ses/-/ses-0.5.2.tgz",
+      "integrity": "sha512-09pHZlxE+d14vVBCGpcaRlWIyFxf6Fyvrc7VkmX1W5GaR6LmjdHJpUixK05Ciu9fOOj6m1js5AFjSkVh/LZ6RA==",
       "requires": {
-        "@agoric/make-hardener": "^0.0.4",
-        "esm": "^3.2.5"
+        "@agoric/make-hardener": "^0.0.6",
+        "esm": "^3.2.25"
+      },
+      "dependencies": {
+        "@agoric/make-hardener": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/@agoric/make-hardener/-/make-hardener-0.0.6.tgz",
+          "integrity": "sha512-OpZcNx/7bhHar0iuQ6D+FKYCMMxqKvYs4aC/bB5v/ffZaSM5sNAl98DnGL1mD9NSyZLGzAZ7D5XwJpe37BMldQ=="
+        }
       }
     },
     "set-blocking": {
@@ -2786,6 +2912,11 @@
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -3172,6 +3303,11 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -3182,6 +3318,11 @@
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tslib": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agoric/ertp": "^0.0.7",
+    "@agoric/ertp": "0.0.8",
     "@agoric/evaluate": "file:agoric-evaluate-0.0.1.tgz",
-    "@agoric/swingset-vat": "^0.0.14",
+    "@agoric/swingset-vat": "0.0.15",
     "@iarna/toml": "^2.2.3",
     "bindings": "^1.2.1",
     "deterministic-json": "^1.0.5",


### PR DESCRIPTION
Infix Bang Done Right.  The support is fully in [SwingSet](https://github.com/Agoric/SwingSet), which we crib off of.  In the future, enhancements to infix bang will be incorporated simply by updating the `@agoric/swingset-vat` dependency.

Sample code is in README-gallery-demo.md.

To color a pixel ASAP, use:
```
home.gallery!changeColor(home.gallery!split(home.gallery!tapFaucet())!useRightPayment, 'yellow')
```
