### PR TITLE
Persistent chain pubkeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ build
 node_modules
 t[0-9]/
 
-ve3/
-ve3-client/
+ve[0-9]/
+ve[0-9]-client/
 *.egg-info/
 __pycache__/
 chains

--- a/bin/ag-solo
+++ b/bin/ag-solo
@@ -3,7 +3,13 @@
 const process = require('process');
 require = require('esm')(module);
 const solo = require('../lib/ag-solo/main.js').default;
-solo(process.argv[1], process.argv.splice(2))
-  .then(_res => 0,
-        rej => console.log(`error running ag-solo:`, rej));
 
+solo(process.argv[1], process.argv.splice(2)).then(
+  _res => 0,
+  rej => {
+    console.log(`error running ag-solo:`, rej);
+    console.error(`\
+Maybe the chain has bumped and you need to rerun ag-setup-solo?`);
+    process.exit(1);
+  },
+);

--- a/lib/ag-solo/init-basedir.js
+++ b/lib/ag-solo/init-basedir.js
@@ -7,10 +7,12 @@ export default function initBasedir(basedir, webport, webhost, subdir) {
   try {
     fs.mkdirSync(basedir);
   } catch (e) {
-    console.log(
-      `unable to create basedir ${basedir}, it must not already exist`,
-    );
-    throw e;
+    if (!fs.existsSync(path.join(basedir, 'ag-cosmos-helper-address'))) {
+      console.log(
+        `unable to create basedir ${basedir}, it must not already exist`,
+      );
+      throw e;
+    }
   }
 
   const connections = [{ type: 'http', port: webport, host: webhost }];
@@ -80,32 +82,34 @@ export default function initBasedir(basedir, webport, webhost, subdir) {
 
   // cosmos-sdk keypair
   const agchServerDir = path.join(basedir, 'ag-cosmos-helper-statedir');
-  fs.mkdirSync(agchServerDir);
-  // we assume 'ag-cosmos-helper' is on $PATH for now, see chain-cosmos-sdk.js
-  const keyName = 'ag-solo';
-  const password = 'mmmmmmmm\n';
-  // we suppress stderr because it displays the mnemonic phrase, but
-  // unfortunately that means errors are harder to diagnose
-  execFileSync(
-    'ag-cosmos-helper',
-    ['keys', 'add', keyName, '--home', agchServerDir],
-    {
-      input: Buffer.from(password),
-      stdio: ['pipe', 'ignore', 'ignore'],
-    },
-  );
-  console.log('key generated, now extracting address');
-  const kout = execFileSync(
-    'ag-cosmos-helper',
-    ['keys', 'show', keyName, '--address', '--home', agchServerDir],
-    {
-      stdio: ['ignore', 'pipe', 'inherit'],
-    },
-  );
-  fs.writeFileSync(
-    path.join(basedir, 'ag-cosmos-helper-address'),
-    kout.toString(),
-  );
+  if (!fs.existsSync(agchServerDir)) {
+    fs.mkdirSync(agchServerDir);
+    // we assume 'ag-cosmos-helper' is on $PATH for now, see chain-cosmos-sdk.js
+    const keyName = 'ag-solo';
+    const password = 'mmmmmmmm\n';
+    // we suppress stderr because it displays the mnemonic phrase, but
+    // unfortunately that means errors are harder to diagnose
+    execFileSync(
+      'ag-cosmos-helper',
+      ['keys', 'add', keyName, '--home', agchServerDir],
+      {
+        input: Buffer.from(password),
+        stdio: ['pipe', 'ignore', 'ignore'],
+      },
+    );
+    console.log('key generated, now extracting address');
+    const kout = execFileSync(
+      'ag-cosmos-helper',
+      ['keys', 'show', keyName, '--address', '--home', agchServerDir],
+      {
+        stdio: ['ignore', 'pipe', 'inherit'],
+      },
+    );
+    fs.writeFileSync(
+      path.join(basedir, 'ag-cosmos-helper-address'),
+      kout.toString(),
+    );
+  }
 
   // this marker file is how we recognize ag-solo basedirs
   fs.copyFileSync(

--- a/lib/ag-solo/main.js
+++ b/lib/ag-solo/main.js
@@ -70,7 +70,7 @@ start
   } else if (argv[0] === 'start') {
     const basedir = insistIsBasedir();
     const withSES = true;
-    start(basedir, withSES, argv.slice(1));
+    await start(basedir, withSES, argv.slice(1));
   } else {
     console.log(`unrecognized command ${argv[0]}`);
     console.log(`try one of: init, set-gci-ingress, start`);

--- a/lib/ag-solo/set-gci-ingress.js
+++ b/lib/ag-solo/set-gci-ingress.js
@@ -8,14 +8,58 @@ export default function setGCIIngress(basedir, GCI, rpcAddresses, chainID) {
     .toString()
     .trim();
   const fn = path.join(basedir, 'connections.json');
-  const connections = JSON.parse(fs.readFileSync(fn));
-  connections.push({
+  const connsByType = {};
+  const add = c => {
+    const { type } = c;
+    const conns = connsByType[type];
+    if (!conns) {
+      connsByType[type] = [c];
+      return;
+    }
+
+    switch (type) {
+      case 'chain-cosmos-sdk': {
+        // Replace duplicate GCIs.
+        const { GCI: newGCI, rpcAddresses: newRpcAddresses } = c;
+        const index = conns.findIndex(
+          ({ GCI: oldGCI, rpcAddresses: oldRpcAddresses }) => {
+            if (oldGCI === newGCI) {
+              return true;
+            }
+            for (const r of newRpcAddresses) {
+              // Overlapping RPC address.
+              if (oldRpcAddresses.includes(r)) {
+                return true;
+              }
+            }
+            return false;
+          },
+        );
+        if (index < 0) {
+          conns.push(c);
+        } else {
+          conns[index] = c;
+        }
+        break;
+      }
+      default:
+        conns.push(c);
+    }
+  };
+
+  JSON.parse(fs.readFileSync(fn)).forEach(add);
+  const newconn = {
     type: 'chain-cosmos-sdk',
     chainID,
     GCI,
     rpcAddresses,
     myAddr,
-  });
+  };
+  add(newconn);
+  const connections = [];
+  Object.entries(connsByType).forEach(([type, conns]) =>
+    connections.push(...conns),
+  );
   fs.writeFileSync(fn, `${JSON.stringify(connections, undefined, 2)}\n`);
 
   const gciFileContents = `\

--- a/lib/ag-solo/set-gci-ingress.js
+++ b/lib/ag-solo/set-gci-ingress.js
@@ -19,11 +19,25 @@ export default function setGCIIngress(basedir, GCI, rpcAddresses, chainID) {
 
     switch (type) {
       case 'chain-cosmos-sdk': {
-        // Replace duplicate GCIs.
-        const { GCI: newGCI, rpcAddresses: newRpcAddresses } = c;
+        // Replace duplicate GCIs, rpcAddresses, or base chainIDs.
+        const {
+          GCI: newGCI,
+          chainID: newChainID,
+          rpcAddresses: newRpcAddresses,
+        } = c;
+        const getBase = id => {
+          const s = String(id);
+          const match = s.match(/^(.*[^\d.])[\d.]*$/);
+          return match ? match[1] : s;
+        };
+        const newBase = getBase(newChainID);
         const index = conns.findIndex(
-          ({ GCI: oldGCI, rpcAddresses: oldRpcAddresses }) => {
-            if (oldGCI === newGCI) {
+          ({
+            GCI: oldGCI,
+            chainID: oldChainID,
+            rpcAddresses: oldRpcAddresses,
+          }) => {
+            if (oldGCI === newGCI || getBase(oldChainID) === newBase) {
               return true;
             }
             for (const r of newRpcAddresses) {

--- a/lib/ag-solo/start.js
+++ b/lib/ag-solo/start.js
@@ -26,8 +26,6 @@ import { connectToChain } from './chain-cosmos-sdk';
 // import { makeChainFollower } from './follower';
 // import { makeDeliverator } from './deliver-with-ag-cosmos-helper';
 
-console.log('Promise.makeHandled', typeof Promise.makeHandled, typeof Promise.prototype.get);
-
 async function buildSwingset(stateFile, withSES, vatsDir, argv) {
   const state = JSON.parse(fs.readFileSync(stateFile));
   const config = await loadBasedir(vatsDir);
@@ -109,30 +107,32 @@ export default async function start(basedir, withSES, argv) {
     broadcastJSON(obj);
   }
 
-  connections.forEach(async c => {
-    if (c.type === 'chain-cosmos-sdk') {
-      console.log(`adding follower/sender for GCI ${c.GCI}`);
-      // c.rpcAddresses are strings of host:port for the RPC ports of several
-      // chain nodes
-      const deliverator = await connectToChain(
-        basedir,
-        c.GCI,
-        c.rpcAddresses,
-        c.myAddr,
-        inbound,
-        c.chainID,
-      );
-      addDeliveryTarget(c.GCI, deliverator);
-    } else if (c.type === 'http') {
-      console.log(`adding HTTP/WS listener on ${c.host}:${c.port}`);
-      if (broadcastJSON) {
-        throw new Error(`duplicate type=http in connections.json`);
+  await Promise.all(
+    connections.map(async c => {
+      if (c.type === 'chain-cosmos-sdk') {
+        console.log(`adding follower/sender for GCI ${c.GCI}`);
+        // c.rpcAddresses are strings of host:port for the RPC ports of several
+        // chain nodes
+        const deliverator = await connectToChain(
+          basedir,
+          c.GCI,
+          c.rpcAddresses,
+          c.myAddr,
+          inbound,
+          c.chainID,
+        );
+        addDeliveryTarget(c.GCI, deliverator);
+      } else if (c.type === 'http') {
+        console.log(`adding HTTP/WS listener on ${c.host}:${c.port}`);
+        if (broadcastJSON) {
+          throw new Error(`duplicate type=http in connections.json`);
+        }
+        broadcastJSON = makeHTTPListener(basedir, c.port, c.host, command);
+      } else {
+        throw new Error(`unknown connection type in ${c}`);
       }
-      broadcastJSON = makeHTTPListener(basedir, c.port, c.host, command);
-    } else {
-      throw new Error(`unknown connection type in ${c}`);
-    }
-  });
+    }),
+  );
 
   const vatsDir = path.join(basedir, 'vats');
   const d = await buildSwingset(stateFile, withSES, vatsDir, argv);

--- a/lib/launch-chain.js
+++ b/lib/launch-chain.js
@@ -2,7 +2,6 @@ import { readdirSync } from 'fs';
 
 import djson from 'deterministic-json';
 import {
-  loadBasedir,
   buildVatController,
   buildMailboxStateMap,
   buildMailbox,

--- a/provisioning-server/setup.py
+++ b/provisioning-server/setup.py
@@ -19,6 +19,7 @@ setup(
     package_data={"ag_pserver": ['html/*']},
     install_requires=[
         "twisted[tls]",
+        "pynetstring",
         "magic-wormhole",
         "treq",
         ],

--- a/provisioning-server/setup.py
+++ b/provisioning-server/setup.py
@@ -19,7 +19,6 @@ setup(
     package_data={"ag_pserver": ['html/*']},
     install_requires=[
         "twisted[tls]",
-        "pynetstring",
         "magic-wormhole",
         "treq",
         ],

--- a/setup-solo/src/ag_setup_solo/main.py
+++ b/setup-solo/src/ag_setup_solo/main.py
@@ -9,30 +9,43 @@ import shutil
 import subprocess
 import sys
 import os
+import urllib.request
 
 MAILBOX_URL = u"ws://relay.magic-wormhole.io:4000/v1"
 #MAILBOX_URL = u"ws://10.0.2.24:4000/v1"
 APPID = u"agoric.com/ag-testnet1/provisioning-tool"
+NETWORK_CONFIG = "https://testnet.agoric.com/network-config"
+DEFAULT_SWINGSTATE_JSON = json.dumps({"mailbox": {}, "kernel": {}})
 
 # Locate the ag-solo binary.
-AG_SOLO = os.path.abspath('bin/ag-solo')
-if not os.path.exists(AG_SOLO):
+# Look up until we find a different bin directory.
+candidate = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
+AG_SOLO = os.path.join(candidate, 'bin', 'ag-solo')
+while not os.path.exists(AG_SOLO):
+  next_candidate = os.path.dirname(candidate)
+  if next_candidate == candidate:
     AG_SOLO = 'ag-solo'
-
-START_DIR = os.path.abspath('.')
+    break
+  candidate = next_candidate
+  AG_SOLO = os.path.join(candidate, 'bin', 'ag-solo')
 
 class Options(usage.Options):
     optParameters = [
         ["webhost", "h", "127.0.0.1", "client-visible HTTP listening address"],
         ["webport", "p", "8000", "client-visible HTTP listening port"],
+        ["netconfig", None, NETWORK_CONFIG, "website for network config"]
     ]
     def parseArgs(self, basedir=os.environ.get('AG_SOLO_BASEDIR', 'agoric')):
         self['basedir'] = os.environ['AG_SOLO_BASEDIR'] = basedir
 
+
+def setIngressAndRestart(sm):
+    subprocess.run([AG_SOLO, 'set-gci-ingress', '--chainID=%s' % sm['chainName'], sm['gci'], *sm['rpcAddrs']], check=True)
+    os.execvp(AG_SOLO, [AG_SOLO, 'start', '--role=client'])
+
 @defer.inlineCallbacks
 def run_client(reactor, o, pubkey):
     w = wormhole.create(APPID, MAILBOX_URL, reactor)
-    # FIXME: Handle SIGINT!
     wormhole.input_with_completion("Provisioning code: ", w.input_code(), reactor)
     cm = json.dumps({
         "pubkey": pubkey,
@@ -48,8 +61,7 @@ def run_client(reactor, o, pubkey):
         return
 
     BASEDIR = o['basedir']
-    subprocess.run([AG_SOLO, 'set-gci-ingress', '--chainID=%s' % sm['chainName'], sm['gci'], *sm['rpcAddrs']], check=True)
-    os.execvp(AG_SOLO, [AG_SOLO, 'start', '--role=client'])
+    setIngressAndRestart(sm)
 
 def doInit(o):
     BASEDIR = o['basedir']
@@ -63,12 +75,23 @@ def main():
     # If it doesn't exist, run the ag-solo init.
     if os.path.exists(pkeyFile):
         print(pkeyFile + ' already exists!')
-        yesno = input('Type "yes" to reinitialize, anything else cancels: ')
+        yesno = input('Type "yes" to reset state from ' + o['netconfig'] + ', anything else cancels: ')
         if yesno.strip() != 'yes':
             print('Cancelling!')
             sys.exit(1)
-        shutil.rmtree(o['basedir'], ignore_errors=True, onerror=None)
-        doInit(o)
+        
+        resp = urllib.request.urlopen(o['netconfig'])
+        encoding = resp.headers.get_content_charset('utf-8')
+        decoded = resp.read().decode(encoding)
+        netconfig = json.loads(decoded)
+
+        # Truncate the default swingstate.json.
+        # FIXME: It would be nicer if SwingSet state was kept in its own
+        # directory, then we could just shutil.rmtree(it).
+        with open(os.path.join(o['basedir'], 'swingstate.json'), 'w') as f:
+          f.write(DEFAULT_SWINGSTATE_JSON)
+
+        setIngressAndRestart(netconfig)
     else:
         doInit(o)
 

--- a/setup/main.js
+++ b/setup/main.js
@@ -472,14 +472,12 @@ show-config      display the client connection parameters
       initHint();
 
       console.error(
-        chalk.black.bgGreenBright.bold(
-          `Go to the provisioning server at: ${pserverUrl}
-or "curl '${pserverUrl}/request-code?nickname=MY-NICK'"`,
-        ),
+        `Go to the provisioning server at: ${chalk.yellow.bold(pserverUrl)}
+or "${chalk.yellow.bold(`curl '${pserverUrl}/request-code?nickname=MY-NICK'`)}"`,
       );
       if (await exists('/vagrant')) {
         console.log(`to publish a chain-connected server to your host, do something like:
-${chalk.yellow.bold(`"ve3/bin/ag-setup-solo --webhost=0.0.0.0"`)}`);
+"${chalk.yellow.bold(`ve3/bin/ag-setup-solo --webhost=0.0.0.0`)}"`);
       }
       break;
     }

--- a/setup/main.js
+++ b/setup/main.js
@@ -413,6 +413,21 @@ show-config      display the client connection parameters
         ]),
       );
 
+      // Install any pubkeys from a former instantiation.
+      await guardFile(`${CONTROLLER_DIR}/pubkeys.stamp`, () =>
+        needReMain([
+          'ssh',
+          'ag-pserver',
+          'sudo',
+          '-u',
+          'ag-pserver',
+          '/usr/src/app/ve3/bin/ag-pserver',
+          'add-pubkeys',
+          '-c',
+          'http://localhost:8000/vat',
+        ]),
+      );
+
       let pserverFlags = '';
       const installFlags = [];
       const pub = `${networkName}.crt`;


### PR DESCRIPTION
These changes make the ag-pserver record a database of provisioned cosmos public keys, nicknames, and testnet versions when they were first used.   When bumping the testnet with ag-setup-cosmos, this state is preserved and is used to reinitialize the public keys and ingresses in the new network (as if the magic wormhole provisioning was redone with every testnet bump).

Additional support is done in ag-setup-solo to prune the SwingSet state and fetch the new testnet configuration from a public website.  Then, the config is merged into connections.json, and ag-solo is restarted.

ag-solo is also updated to properly report and error out on mismatched state between client and chain, with a helpful message to rerun ag-setup-solo to reset the needed state without having to go through the (magic wormhole) provisioning again.

This PR was thoroughly tested with the new Vagrant/Docker setup.  It should be ready for the testnet.
