### PR TITLE
fix swapped pixel axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ You might see something like:
 ```
 
 The `quantity` tells us which pixels we've received. `{ x:1, y:4 }`
-means that we got a pixel that is in the second row (`x:1`) and 5 pixels
-from the left (`y:4`). To color the pixel, we need to get the use
+means that we got a pixel that is in the fifth row (`y:4`) and 2 pixels
+from the left (`x:1`). To color the pixel, we need to get the use
 object from the payment. You can think of the use object as a regular
 JavaScript object that just happens to be associated with an ERTP
 payment. 

--- a/lib/ag-solo/html/main.js
+++ b/lib/ag-solo/html/main.js
@@ -110,7 +110,8 @@ function run() {
       galleryNode.removeChild(galleryNode.firstChild);
     }
     // We need to render increasing x followed by increasing y.
-    for (let y = 0; y < state[0].length; y += 1) {
+    const maxHeight = state.reduce((prior, column) => Math.max(prior, column.length), 0);
+    for (let y = 0; y < maxHeight; y += 1) {
       for (let x = 0; x < state.length; x += 1) {
         const px = document.createElement('div');
         px.id = `pix${x}.${y}`;
@@ -148,8 +149,8 @@ function run() {
       void px.offsetWidth;
       px.classList.add('updated');
     }
-    for (let y = 0; y < state[0].length; y += 1) {
-      for (let x = 0; x < state.length; x += 1) {
+    for (let x = 0; x < state.length; x += 1) {
+      for (let y = 0; y < state[x].length; y += 1) {
         const newcolor = state[x][y];
         if (newcolor !== oldState[x][y]) {
           renderPixel(x, y, newcolor);

--- a/lib/ag-solo/html/main.js
+++ b/lib/ag-solo/html/main.js
@@ -109,8 +109,9 @@ function run() {
     while (galleryNode.firstChild) {
       galleryNode.removeChild(galleryNode.firstChild);
     }
-    for (let x = 0; x < state.length; x += 1) {
-      for (let y = 0; y < state.length; y += 1) {
+    // We need to render increasing x followed by increasing y.
+    for (let y = 0; y < state[0].length; y += 1) {
+      for (let x = 0; x < state.length; x += 1) {
         const px = document.createElement('div');
         px.id = `pix${x}.${y}`;
         px.className = 'pixel';
@@ -147,8 +148,8 @@ function run() {
       void px.offsetWidth;
       px.classList.add('updated');
     }
-    for (let x = 0; x < state.length; x += 1) {
-      for (let y = 0; y < state.length; y += 1) {
+    for (let y = 0; y < state[0].length; y += 1) {
+      for (let x = 0; x < state.length; x += 1) {
         const newcolor = state[x][y];
         if (newcolor !== oldState[x][y]) {
           renderPixel(x, y, newcolor);


### PR DESCRIPTION
The created pixel `div` elements were not labelled correctly (the x and y coordinates were reversed).

This PR fixes that, as well as updating the README.
