### PR TITLE
Raise throughput limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ scenario2-setup:
 	-rm -r ~/.ag-chain-cosmos
 	-rm ag-cosmos-chain-state.json
 	$(AGC) init --chain-id=$(CHAIN_ID)
-	./set-json.js ~/.ag-chain-cosmos/config/genesis.json app_state.auth.params.tx_size_cost_per_byte='"0"'
+	./setup/set-json.js ~/.ag-chain-cosmos/config/genesis.json --agoric-genesis-overrides
 	rm -rf t1
 	bin/ag-solo init t1
 	$(AGC) add-genesis-account `cat t1/ag-cosmos-helper-address` $(INITIAL_TOKENS)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ scenario2-setup:
 	-rm -r ~/.ag-chain-cosmos
 	-rm ag-cosmos-chain-state.json
 	$(AGC) init --chain-id=$(CHAIN_ID)
+	./set-json.js ~/.ag-chain-cosmos/config/genesis.json app_state.auth.params.tx_size_cost_per_byte='"0"'
 	rm -rf t1
 	bin/ag-solo init t1
 	$(AGC) add-genesis-account `cat t1/ag-cosmos-helper-address` $(INITIAL_TOKENS)

--- a/lib/ag-solo/chain-cosmos-sdk.js
+++ b/lib/ag-solo/chain-cosmos-sdk.js
@@ -1,11 +1,16 @@
 import path from 'path';
+import fs from 'fs';
 import fetch from 'node-fetch';
 import { execFile } from 'child_process';
 import djson from 'deterministic-json';
 import { createHash } from 'crypto';
+import { open as tempOpen } from 'temp';
 import connect from 'lotion-connect';
 
 const HELPER = 'ag-cosmos-helper';
+
+const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+
 const WAS_CANCELLED_EXCEPTION = {
   toString() {
     return 'WAS_CANCELLED_EXCEPTION';
@@ -108,19 +113,24 @@ export async function connectToChain(
       let ret;
       try {
         ret = await new Promise((resolve, reject) => {
-          const proc = execFile(HELPER, fullArgs, (error, stdout, stderr) => {
-            if (error) {
-              return reject(error);
-            }
-            resolve({ stdout, stderr });
-          });
+          const proc = execFile(
+            HELPER,
+            fullArgs,
+            { maxBuffer: MAX_BUFFER_SIZE },
+            (error, stdout, stderr) => {
+              if (error) {
+                return reject(error);
+              }
+              return resolve({ stdout, stderr });
+            },
+          );
           if (stdin) {
             proc.stdin.write(stdin);
             proc.stdin.end();
           }
         });
       } catch (e) {
-        console.log(` failed exec of:`, HELPER, ...fullArgs);
+        console.log(` failed exec:`, e);
       }
 
       await throwIfCancelled();
@@ -291,52 +301,89 @@ export async function connectToChain(
       })
       .catch(e => console.log(`Failed to fetch ${GCI} mailbox:`, e));
   });
-  function deliver(newMessages, acknum) {
-    console.log(`delivering to chain`, GCI, newMessages, acknum);
+  async function deliver(newMessages, acknum) {
+    let tmpInfo;
+    try {
+      console.log(`delivering to chain`, GCI, newMessages, acknum);
 
-    // TODO: combine peer and submitter in the message format (i.e. remove
-    // the extra 'myAddr' after 'tx swingset deliver'). All messages from
-    // solo vats are "from" the signer, and messages relayed from another
-    // chain will have other data to demonstrate which chain it comes from
+      // TODO: combine peer and submitter in the message format (i.e. remove
+      // the extra 'myAddr' after 'tx swingset deliver'). All messages from
+      // solo vats are "from" the signer, and messages relayed from another
+      // chain will have other data to demonstrate which chain it comes from
 
-    // TODO: remove this JSON.stringify([newMessages, acknum]): change
-    // 'deliverMailboxReq' to have more structure than a single string, and
-    // have the CLI handle variable args better
+      // TODO: remove this JSON.stringify([newMessages, acknum]): change
+      // 'deliverMailboxReq' to have more structure than a single string, and
+      // have the CLI handle variable args better
 
-    const args = [
-      'tx',
-      'swingset',
-      'deliver',
-      myAddr,
-      JSON.stringify([newMessages, acknum]),
-      '--from',
-      'ag-solo',
-      '--broadcast-mode',
-      'block', // Don't return until committed.
-      '--yes',
-    ];
-    const password = 'mmmmmmmm';
+      tmpInfo = await new Promise((resolve, reject) => {
+        tempOpen({ prefix: 'ag-solo-cosmos-deliver.' }, (err, info) => {
+          if (err) {
+            return reject(err);
+          }
+          return resolve(info);
+        });
+      });
 
-    // If we send two messages back-to-back too quickly, the second one
-    // may use the same seqnum as the first, so it will be rejected by the
-    // signature-checking auth/ante handler on the chain. Therefore, we need
-    // to queue our deliver() calls and not allow one to proceed until the
-    // others have finished.
-    return queuedHelper(
-      'deliver',
-      undefined, // allow the queue to grow unbounded, and never cancel deliveries
-      args,
-      ret => {
-        const { stderr, stdout } = ret;
-        console.error(stderr);
-        console.log(` helper said: ${stdout}`);
-        // TODO: parse the helper output (JSON), we want 'code' to be 0. If
-        // not, look at .raw_log (also JSON) at .message.
-        return {};
-      },
-      `${password}\n`,
-      {}, // defaultIfCancelled
-    );
+      try {
+        await new Promise((resolve, reject) => {
+          fs.write(tmpInfo.fd, JSON.stringify([newMessages, acknum]), err => {
+            if (err) {
+              return reject(err);
+            }
+            return resolve();
+          });
+        });
+      } finally {
+        await new Promise((resolve, reject) => {
+          fs.close(tmpInfo.fd, e => {
+            if (e) {
+              return reject(e);
+            }
+            return resolve();
+          });
+        });
+      }
+
+      const args = [
+        'tx',
+        'swingset',
+        'deliver',
+        myAddr,
+        `@${tmpInfo.path}`, // Deliver message over file, as it could be big.
+        '--from',
+        'ag-solo',
+        '--broadcast-mode',
+        'block', // Don't return until committed.
+        '--yes',
+      ];
+      const password = 'mmmmmmmm';
+
+      // If we send two messages back-to-back too quickly, the second one
+      // may use the same seqnum as the first, so it will be rejected by the
+      // signature-checking auth/ante handler on the chain. Therefore, we need
+      // to queue our deliver() calls and not allow one to proceed until the
+      // others have finished.
+      const qret = await queuedHelper(
+        'deliver',
+        undefined, // allow the queue to grow unbounded, and never cancel deliveries
+        args,
+        ret => {
+          const { stderr, stdout } = ret;
+          console.error(stderr);
+          console.log(` helper said: ${stdout}`);
+          // TODO: parse the helper output (JSON), we want 'code' to be 0. If
+          // not, look at .raw_log (also JSON) at .message.
+          return {};
+        },
+        `${password}\n`,
+        {}, // defaultIfCancelled
+      );
+      return qret;
+    } finally {
+      if (tmpInfo) {
+        await fs.promises.unlink(tmpInfo.path);
+      }
+    }
   }
 
   return deliver;

--- a/set-json.js
+++ b/set-json.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Run as: ./set-json MY.json abc=123 'def.ghi="string"'
+// Run as: ./set-json.js SOMETHING.json abc=123 'def.ghi="string"'
 const process = require('process');
 const fs = require('fs');
 

--- a/set-json.js
+++ b/set-json.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+// Run as: ./set-json MY.json abc=123 'def.ghi="string"'
+const process = require('process');
+const fs = require('fs');
+
+// point this at ~/.ag-cosmos-chain/config/genesis.json
+const [file, ...substs] = process.argv.slice(2);
+
+let config;
+try {
+  let configString;
+  if (file === '-') {
+    configString = fs.readFileSync(0, 'utf-8');
+  } else {
+    configString = fs.readFileSync(process.argv[2], 'utf-8');
+  }
+  config = JSON.parse(configString);
+} catch (e) {
+  if (e.code === 'ENOENT') {
+    config = {};
+  } else {
+    throw e;
+  }
+}
+
+for (const pathEquals of substs) {
+  const match = pathEquals.match(/^([^=]+)=(.*)$/);
+  if (!match) {
+    throw Error(`not a path=value argument ${pathEquals}`);
+  }
+  const path = match[1];
+  const jsonVal = match[2];
+  const val = JSON.parse(jsonVal);
+  let obj = config;
+  const ps = path.split('.');
+  for (let i = 0; i < ps.length - 1; i += 1) {
+    const p = ps[i];
+    if (!(p in obj)) {
+      obj[p] = {};
+    }
+    obj = obj[p];
+  }
+
+  obj[ps[ps.length - 1]] = val;
+}
+
+const outString = `${JSON.stringify(config, undefined, 2)}\n`;
+if (file === '-') {
+  process.stdout.write(outString);
+} else {
+  const tmpFile = `${file}.${process.pid}`;
+  try {
+    fs.writeFileSync(tmpFile, outString);
+    fs.renameSync(tmpFile, file);
+  } catch (e) {
+    fs.unlinkSync(tmpFile);
+  }
+}

--- a/setup/main.js
+++ b/setup/main.js
@@ -772,7 +772,16 @@ or "${chalk.yellow.bold(`curl '${pserverUrl}/request-code?nickname=MY-NICK'`)}"`
         validators.push(...obj.validators);
       }
       first.validators = validators;
-      process.stdout.write(JSON.stringify(first, undefined, 2));
+
+      const stdin = streamFromString(JSON.stringify(first, undefined, 2));
+
+      // Apply the Agoric overrides from set-json.js.
+      setSilent(true);
+      await needDoRun(
+        [resolve(__dirname, 'set-json.js'), '-', '--agoric-genesis-overrides'],
+        stdin,
+      );
+
       break;
     }
 

--- a/setup/set-json.js
+++ b/setup/set-json.js
@@ -5,7 +5,18 @@ const process = require('process');
 const fs = require('fs');
 
 // point this at ~/.ag-cosmos-chain/config/genesis.json
-const [file, ...substs] = process.argv.slice(2);
+const [file, ...sargs] = process.argv.slice(2);
+
+const assigns = sargs.reduce((prior, assign) => {
+  if (assign === '--agoric-genesis-overrides') {
+    prior.push(
+      `app_state.auth.params.tx_size_cost_per_byte="0"`,
+    );
+  } else {
+    prior.push(assign);
+  }
+  return prior;
+}, []);
 
 let config;
 try {
@@ -24,7 +35,7 @@ try {
   }
 }
 
-for (const pathEquals of substs) {
+for (const pathEquals of assigns) {
   const match = pathEquals.match(/^([^=]+)=(.*)$/);
   if (!match) {
     throw Error(`not a path=value argument ${pathEquals}`);

--- a/x/swingset/client/cli/query.go
+++ b/x/swingset/client/cli/query.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/Agoric/cosmic-swingset/x/swingset"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -21,7 +22,7 @@ func GetCmdGetStorage(queryRoute string, cdc *codec.Codec) *cobra.Command {
 
 			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/storage/%s", queryRoute, path), nil)
 			if err != nil {
-				fmt.Printf("could not find storage path - %s \n", path)
+				fmt.Fprintf(os.Stderr, "could not find storage path - %s \n", path)
 				return nil
 			}
 
@@ -47,7 +48,7 @@ func GetCmdGetKeys(queryRoute string, cdc *codec.Codec) *cobra.Command {
 
 			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/keys/%s", queryRoute, path), nil)
 			if err != nil {
-				fmt.Printf("could not find keys path - %s \n", path)
+				fmt.Fprintf(os.Stderr, "could not find keys path - %s \n", path)
 				return nil
 			}
 
@@ -70,7 +71,7 @@ func GetCmdMailbox(queryRoute string, cdc *codec.Codec) *cobra.Command {
 
 			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/mailbox/%s", queryRoute, peer), nil)
 			if err != nil {
-				fmt.Printf("could not find peer mailbox - %s \n", peer)
+				fmt.Fprintf(os.Stderr, "could not find peer mailbox - %s \n", peer)
 				return nil
 			}
 

--- a/x/swingset/client/cli/tx.go
+++ b/x/swingset/client/cli/tx.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"fmt"
+	"io/ioutil"
+
 	"github.com/spf13/cobra"
 
 	"github.com/Agoric/cosmic-swingset/x/swingset"
@@ -18,6 +21,7 @@ func GetCmdDeliver(cdc *codec.Codec) *cobra.Command {
 		Use:   "deliver [sender] [json string]",
 		Short: "deliver inbound messages",
 		Args:  cobra.ExactArgs(2),
+		
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
 
@@ -27,7 +31,23 @@ func GetCmdDeliver(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msgs, err := swingset.UnmarshalMessagesJSON(args[1])
+			jsonIn := args[1]
+			if jsonIn[0] == '@' {
+				fname := args[1][1:]
+				if fname == "-" {
+					// Reading from stdin.
+					if _, err := fmt.Scanln(&jsonIn); err != nil {
+						return err
+					}
+				} else {
+					jsonBytes, err := ioutil.ReadFile(fname)
+					if err != nil {
+						return err
+					}
+					jsonIn = string(jsonBytes)
+				}
+			}
+			msgs, err := swingset.UnmarshalMessagesJSON(jsonIn)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
@warner, this was my work to increase the limits that we were running into for message and response sizes.  I'd appreciate a once-over before we bump the testnet tomorrow.  If you can't get to it by then, no worries, this can go out at a different date.

The transaction size gas limit is removed by default (in `setup/set-json.js`), for both the `Makefile:scenario2-setup`  and the `ag-setup-cosmos` program.

The `ag-cosmos-helper tx swingset deliver [ADDR] [JSON]` now accepts a JSON of `@FILENAME`, which reads the content from a file.  `cosmos-chain-sdk.js` uses that feature (currently unconditionally, but maybe eventually only if the message is large) to avoid command-line limits.

`cosmos-chain-sdk.js` also raises the maximum `ag-cosmos-helper query mailbox` return value from 200kB to 10MB.
