### PR TITLE
WIP Initial version to incorporate a registrar.

### DIFF
--- a/lib/ag-solo/vats/bootstrap.js
+++ b/lib/ag-solo/vats/bootstrap.js
@@ -38,10 +38,12 @@ export default function setup(syscall, state, helpers) {
         return harden({
           async createDemoBundle(nickname) {
             const handoff = await E(vats.handoff).getSharedHandoffService();
+            const registrar = await E(vats.registrar).getSharedRegistrar();
             const pixelBundle = await E(vats.pixel).createPixelBundle(nickname);
             return harden({
               ...pixelBundle,
               handoff,
+              registrar,
               contractHost,
             });
           },

--- a/lib/ag-solo/vats/vat-registrar.js
+++ b/lib/ag-solo/vats/vat-registrar.js
@@ -1,0 +1,23 @@
+import harden from '@agoric/harden';
+import { makeRegistrar } from '@agoric/ertp/more/registrar/registrar';
+
+// This vat contains the handoff service for the demo.
+
+function build(E, log) {
+  const sharedRegistrar = makeRegistrar();
+
+  function getSharedRegistrar() {
+    return sharedRegistrar;
+  }
+
+  return harden({ getSharedRegistrar: getSharedRegistrar });
+}
+
+export default function setup(syscall, state, helpers) {
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, helpers.log),
+    helpers.vatID,
+  );
+}


### PR DESCRIPTION
PR FOR DISCUSSION ONLY

See https://github.com/Agoric/ERTP/pull/154 for the underlying service.

This adds a simple Registrar service to the `home` for new users. It
is intended to be used to register "receptionist" objects for new
smart contracts.

The main outstanding issue is that there are no tests.