### PR TITLE
Same origin

### DIFF
--- a/lib/ag-solo/start.js
+++ b/lib/ag-solo/start.js
@@ -195,16 +195,15 @@ export default async function start(basedir, withSES, argv) {
   // Install the contracts, if given a client role.
   if (argv.find(value => value.match(/^--role=.*client/)) !== undefined) {
     const contractsDir = path.join(basedir, 'contracts');
-    const pairs = (await fs.promises.readdir(contractsDir)).reduce(
-      (prior, name) => {
+    const pairs = (await fs.promises.readdir(contractsDir))
+      .sort()
+      .reduce((prior, name) => {
         const match = name.match(CONTRACT_REGEXP);
         if (match) {
           prior.push(`${match[1]}=${contractsDir}/${name}`);
         }
         return prior;
-      },
-      [],
-    );
+      }, []);
 
     if (pairs.length > 0) {
       // eslint-disable-next-line no-await-in-loop

--- a/lib/ag-solo/upload-contract.js
+++ b/lib/ag-solo/upload-contract.js
@@ -51,7 +51,9 @@ export default async function upload(basedir, args) {
     }
   }
 
-  const ws = new WebSocket(wsurl);
+  const originurl = new URL('/', wsurl);
+  originurl.protocol = 'https:';
+  const ws = new WebSocket(wsurl, { origin: originurl.href });
   const exit = makePromise();
   ws.on('open', async () => {
     try {

--- a/lib/ag-solo/vats/vat-http.js
+++ b/lib/ag-solo/vats/vat-http.js
@@ -7,8 +7,14 @@ import { getReplHandler } from './repl';
 function build(E, D) {
   let commandDevice;
   let provisioner;
-  const homeObjects = { LOADING: 'fetching home objects' };
-  let exportedToCapTP = { LOADING: 'fetching home objects' };
+  const loaded = {};
+  loaded.p = new Promise((resolve, reject) => {
+    loaded.res = resolve;
+    loaded.rej = reject;
+  });
+  harden(loaded);
+  const homeObjects = { LOADING: loaded.p };
+  let exportedToCapTP = { LOADING: loaded.p };
 
   let handler = {};
   let canvasState;
@@ -90,9 +96,9 @@ function build(E, D) {
     },
 
     setPresences(ps, privateObjects) {
-      delete homeObjects.LOADING;
-      exportedToCapTP = Object.assign({}, ps, privateObjects);
+      exportedToCapTP = { ...ps, ...privateObjects };
       Object.assign(homeObjects, ps, privateObjects);
+      loaded.res('chain bundle loaded');
       if (ps.canvasStatePublisher) {
         const subscriber = harden({
           notify(m) {

--- a/lib/ag-solo/web.js
+++ b/lib/ag-solo/web.js
@@ -1,5 +1,6 @@
 // Start a network service
 const path = require('path');
+const http = require('http');
 const express = require('express');
 const WebSocket = require('ws');
 const morgan = require('morgan');
@@ -22,17 +23,52 @@ export function makeHTTPListener(basedir, port, host, inboundCommand) {
     ),
   );
   app.use(express.json()); // parse application/json
-  const server = app.listen(port, host, () =>
-    console.log('Listening on', `${host}:${port}`),
-  );
+  const server = http.createServer(app);
 
   // serve the static HTML for the UI
   const htmldir = path.join(basedir, 'html');
   console.log(`Serving static files from ${htmldir}`);
   app.use(express.static(htmldir));
 
+  const validateOrigin = req => {
+    const { origin } = req.headers;
+    const id = `${req.socket.remoteAddress}:${req.socket.remotePort}:`;
+
+    if (!origin) {
+      console.log(id, `Missing origin header`);
+      return false;
+    }
+    const url = new URL(origin);
+    const isLocalhost = hostname =>
+      hostname.match(/^(localhost|127\.0\.0\.1)$/);
+    if (isLocalhost(host)) {
+      if (!isLocalhost(url.hostname)) {
+        console.log(id, `Invalid origin host ${origin} is not local`);
+        return false;
+      }
+    } else if (url.hostname !== host) {
+      console.log(id, `Invalid origin host ${origin}`);
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      console.log(id, `Invalid origin protocol ${origin}`, url.protocol);
+      return false;
+    }
+    if (String(url.port) !== String(port)) {
+      console.log(id, `Invalid origin port ${origin}`, url.port);
+      return false;
+    }
+
+    return true;
+  };
+
   // accept vat messages on /vat
   app.post('/vat', (req, res) => {
+    if (!validateOrigin(req)) {
+      res.json({ ok: false, rej: 'Invalid Origin' });
+      return;
+    }
+
     // console.log(`POST /vat got`, req.body); // should be jsonable
     inboundCommand(req.body).then(
       r => res.json({ ok: true, res: r }),
@@ -45,7 +81,22 @@ export function makeHTTPListener(basedir, port, host, inboundCommand) {
   // GETs (which should return index.html) and WebSocket requests.. it might
   // be better to move the WebSocket listener off to e.g. /ws with a 'path:
   // "ws"' option.
-  const wss = new WebSocket.Server({ server });
+  const wss = new WebSocket.Server({ noServer: true });
+  server.on('upgrade', (req, socket, head) => {
+    if (!validateOrigin(req)) {
+      socket.destroy();
+      return;
+    }
+
+    wss.handleUpgrade(req, socket, head, ws => {
+      wss.emit('connection', ws, req);
+    });
+  });
+
+  server.listen(port, host, () =>
+    console.log('Listening on', `${host}:${port}`),
+  );
+
   let lastConnectionID = 0;
 
   function newConnection(ws, req) {

--- a/lib/ag-solo/web.js
+++ b/lib/ag-solo/web.js
@@ -41,24 +41,16 @@ export function makeHTTPListener(basedir, port, host, inboundCommand) {
     const url = new URL(origin);
     const isLocalhost = hostname =>
       hostname.match(/^(localhost|127\.0\.0\.1)$/);
-    if (isLocalhost(host)) {
-      if (!isLocalhost(url.hostname)) {
-        console.log(id, `Invalid origin host ${origin} is not local`);
-        return false;
-      }
-    } else if (url.hostname !== host) {
-      console.log(id, `Invalid origin host ${origin}`);
+
+    if (!isLocalhost(url.hostname)) {
+      console.log(id, `Invalid origin host ${origin} is not localhost`);
+      return false;
     }
 
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
       console.log(id, `Invalid origin protocol ${origin}`, url.protocol);
       return false;
     }
-    if (String(url.port) !== String(port)) {
-      console.log(id, `Invalid origin port ${origin}`, url.port);
-      return false;
-    }
-
     return true;
   };
 

--- a/provisioning-server/src/ag_pserver/main.py
+++ b/provisioning-server/src/ag_pserver/main.py
@@ -225,7 +225,10 @@ def enablePubkey(reactor, opts, config, nickname, pubkey):
     # be routed to vat-provisioning.js and the pleaseProvision() method.
     try:
         resp = yield treq.post(controller_url, m.encode('utf-8'), reactor=reactor,
-                                headers={b'Content-Type': [b'application/json']})
+                                headers={
+                                    b'Content-Type': [b'application/json'],
+                                    b'Origin': [controller_url.encode('utf-8')],
+                                })
         if resp.code < 200 or resp.code >= 300:
             raise Exception('invalid response code ' + str(resp.code))
         rawResp = yield treq.json_content(resp)

--- a/provisioning-server/src/ag_pserver/main.py
+++ b/provisioning-server/src/ag_pserver/main.py
@@ -227,7 +227,7 @@ def enablePubkey(reactor, opts, config, nickname, pubkey):
         resp = yield treq.post(controller_url, m.encode('utf-8'), reactor=reactor,
                                 headers={
                                     b'Content-Type': [b'application/json'],
-                                    b'Origin': [controller_url.encode('utf-8')],
+                                    b'Origin': [b'http://127.0.0.1'],
                                 })
         if resp.code < 200 or resp.code >= 300:
             raise Exception('invalid response code ' + str(resp.code))


### PR DESCRIPTION
This prevents remote web pages from directly accessing the /vat and websocket endpoints of ag-solo.  Only localhost pages (such as the ones served from ag-solo) are allowed.

Note that this doesn't prevent locally-running programs that are not web browsers from access, since they can add their own Origin headers.  At least that's not worse than before.
