### PR TITLE
Record chain/solo kernel state in lines of JSON

### DIFF
--- a/lib/ag-solo/init-basedir.js
+++ b/lib/ag-solo/init-basedir.js
@@ -86,13 +86,11 @@ export default function initBasedir(basedir, webport, webhost, subdir, egresses)
     path.join(basedir, 'node_modules'),
   );
 
-  const initialState = {
-    mailbox: {},
-    kernel: {},
-  };
-
-  const stateFile = path.join(basedir, 'swingstate.json');
-  fs.writeFileSync(stateFile, `${JSON.stringify(initialState)}\n`);
+  const mailboxStateFile = path.resolve(basedir, 'swingset-mailbox-state.json');
+  fs.writeFileSync(mailboxStateFile, `{}\n`);
+  const kernelStateFile = path.resolve(basedir, 'swingset-kernel-state.jsonlines');
+  // this contains newline-terminated lines of JSON.stringify(['key', 'value'])
+  fs.writeFileSync(kernelStateFile, ``);
 
   // cosmos-sdk keypair
   if (egresses.includes('cosmos')) {

--- a/lib/ag-solo/start.js
+++ b/lib/ag-solo/start.js
@@ -92,22 +92,17 @@ async function buildSwingset(mailboxStateFile, kernelStateFile, withSES, vatsDir
     options: { enablePipelining: true },
   });
   config.vats.set('timer', { sourcepath: getTimerWrapperSourcePath() });
+
   // 'storage' will be modified in-place as the kernel runs
   const storage = buildStorageInMemory();
   config.hostStorage = storage.storage;
 
-  let l;
-  try {
-    l = new readlines(kernelStateFile);
-  } catch(e) {
-    console.log(`initializing empty swingset state`);
-  }
-  if (l) {
-    let line;
-    while ((line = l.next())) {
-      const [key, value] = JSON.parse(line);
-      config.hostStorage.set(key, value);
-    }
+  // kernelStateFile is created in init-basedir.js, should never be missing
+  const lines = new readlines(kernelStateFile);
+  let line;
+  while ((line = lines.next())) {
+    const [key, value] = JSON.parse(line);
+    config.hostStorage.set(key, value);
   }
 
   const controller = await buildVatController(config, withSES, argv);

--- a/lib/ag-solo/start.js
+++ b/lib/ag-solo/start.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import temp from 'temp';
 import { promisify } from 'util';
+import readlines from 'n-readlines';
 // import { createHash } from 'crypto';
 
 // import connect from 'lotion-connect';
@@ -70,11 +71,11 @@ async function atomicReplaceFile(filename, contents) {
   }
 }
 
-async function buildSwingset(stateFile, withSES, vatsDir, argv) {
-  const initialState = JSON.parse(fs.readFileSync(stateFile));
+async function buildSwingset(mailboxStateFile, kernelStateFile, withSES, vatsDir, argv) {
+  const initialMailboxState = JSON.parse(fs.readFileSync(mailboxStateFile));
 
   const mbs = buildMailboxStateMap();
-  mbs.populateFromData(initialState.mailbox);
+  mbs.populateFromData(initialMailboxState);
   const mb = buildMailbox(mbs);
   const cm = buildCommand();
   const timer = buildTimer();
@@ -92,17 +93,38 @@ async function buildSwingset(stateFile, withSES, vatsDir, argv) {
   });
   config.vats.set('timer', { sourcepath: getTimerWrapperSourcePath() });
   // 'storage' will be modified in-place as the kernel runs
-  const storage = buildStorageInMemory(initialState.kernel);
+  const storage = buildStorageInMemory();
   config.hostStorage = storage.storage;
+
+  let l;
+  try {
+    l = new readlines(kernelStateFile);
+  } catch(e) {
+    console.log(`initializing empty swingset state`);
+  }
+  if (l) {
+    let line;
+    while ((line = l.next())) {
+      const [key, value] = JSON.parse(line);
+      config.hostStorage.set(key, value);
+    }
+  }
 
   const controller = await buildVatController(config, withSES, argv);
 
   async function saveState() {
-    const s = {
-      mailbox: mbs.exportToData(),
-      kernel: storage.getState(),
-    };
-    await atomicReplaceFile(stateFile, JSON.stringify(s));
+    const ms = JSON.stringify(mbs.exportToData());
+    await atomicReplaceFile(mailboxStateFile, ms);
+    const tmpfn = `${kernelStateFile}.tmp`;
+    const fd = fs.openSync(tmpfn, 'w');
+
+    for (let [key, value] of storage.map.entries()) {
+      const line = JSON.stringify([key, value]);
+      fs.writeSync(fd, line);
+      fs.writeSync(fd, '\n');
+    }
+    fs.closeSync(fd);
+    fs.renameSync(tmpfn, kernelStateFile);
   }
 
   async function processKernel() {
@@ -158,7 +180,8 @@ async function buildSwingset(stateFile, withSES, vatsDir, argv) {
 }
 
 export default async function start(basedir, withSES, argv) {
-  const stateFile = path.resolve(basedir, 'swingstate.json');
+  const mailboxStateFile = path.resolve(basedir, 'swingset-mailbox-state.json');
+  const kernelStateFile = path.resolve(basedir, 'swingset-kernel-state.jsonlines');
   const connections = JSON.parse(
     fs.readFileSync(path.join(basedir, 'connections.json')),
   );
@@ -211,7 +234,7 @@ export default async function start(basedir, withSES, argv) {
   );
 
   const vatsDir = path.join(basedir, 'vats');
-  const d = await buildSwingset(stateFile, withSES, vatsDir, argv);
+  const d = await buildSwingset(mailboxStateFile, kernelStateFile, withSES, vatsDir, argv);
   ({ deliverInboundToMbx, deliverInboundCommand } = d);
   if (broadcastJSON) {
     d.registerBroadcastCallback(broadcast);

--- a/lib/launch-chain.js
+++ b/lib/launch-chain.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import djson from 'deterministic-json';
+import readlines from 'n-readlines';
 import {
   buildMailbox,
   buildMailboxStateMap,
@@ -56,19 +57,22 @@ export async function launch(mailboxStorage, stateFile, vatsDir, argv) {
   const mailboxState = mailboxStorage.has('mailbox')
     ? JSON.parse(mailboxStorage.get('mailbox'))
     : {};
-  let initialState;
+
+  const storage = buildStorageInMemory();
+
+  let l;
   try {
-    const initialStateJSON = fs.readFileSync(stateFile);
-    console.log(
-      `launch: found saved swingset state, size= ${initialStateJSON.length}`,
-    );
-    initialState = JSON.parse(initialStateJSON);
-  } catch (e) {
-    console.log(`launch: initializing empty swingset state`);
-    initialState = {};
+    l = new readlines(stateFile);
+  } catch(e) {
+    console.log(`initializing empty swingset state`);
   }
-  // 'storage' will be modified in-place as the kernel runs
-  const storage = buildStorageInMemory(initialState);
+  if (l) {
+    let line;
+    while ((line = l.next())) {
+      const [key, value] = JSON.parse(line);
+      storage.storage.set(key, value);
+    }
+  }
 
   console.log(`buildSwingset`);
   const { controller, mb, mbs, timer } = await buildSwingset(
@@ -78,14 +82,30 @@ export async function launch(mailboxStorage, stateFile, vatsDir, argv) {
     vatsDir,
     argv,
   );
+
+  function saveKernelState() {
+    const tmpfn = `${stateFile}.tmp`;
+    const fd = fs.openSync(tmpfn, 'w');
+    let size = 0;
+
+    for (let [key, value] of storage.map.entries()) {
+      const line = JSON.stringify([key, value]);
+      fs.writeSync(fd, line);
+      fs.writeSync(fd, '\n');
+      size += line.length + 1;
+    }
+    fs.closeSync(fd);
+    fs.renameSync(tmpfn, stateFile);
+    return size;
+  }
+
   function saveState() {
     // save kernel state to the stateFile, and the mailbox state to a cosmos
     // kvstore where it can be queried externally
-    const kernelState = JSON.stringify(storage.getState());
-    fs.writeFileSync(stateFile, kernelState);
+    const kernelStateSize = saveKernelState();
     const mailboxStateData = djson.stringify(mbs.exportToData());
     mailboxStorage.set(`mailbox`, mailboxStateData);
-    return [kernelState.length, mailboxStateData.length];
+    return [kernelStateSize, mailboxStateData.length];
   }
 
   // save the initial state immediately

--- a/lib/launch-chain.js
+++ b/lib/launch-chain.js
@@ -62,6 +62,7 @@ export async function launch(mailboxStorage, stateFile, vatsDir, argv) {
 
   let l;
   try {
+    // stateFile will be missing the first time we launch
     l = new readlines(stateFile);
   } catch(e) {
     console.log(`initializing empty swingset state`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1788,6 +1788,11 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "n-readlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/n-readlines/-/n-readlines-1.0.0.tgz",
+      "integrity": "sha512-ISDqGcspVu6U3VKqtJZG1uR55SmNNF9uK0EMq1IvNVVZOui6MW6VR0+pIZhqz85ORAGp+4zW+5fJ/SE7bwEibA=="
+    },
     "napi-thread-safe-callback": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/napi-thread-safe-callback/-/napi-thread-safe-callback-0.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express": "^4.17.0",
     "minimist": "^1.2.0",
     "morgan": "^1.9.1",
+    "n-readlines": "^1.0.0",
     "node-fetch": "^2.6.0",
     "rollup": "^1.24.0",
     "rollup-plugin-node-resolve": "^5.2.0",


### PR DESCRIPTION
This replaces the monolithic JSON statefile with a file that contains lines of JSON-serialized key/value pairs. The total size is about the same, but the new format can be written out directly from the `Map` without a 3x memory usage penalty (one copy in the Map, one in an object that can be JSON-serialized, and a third in the string that comes out of `JSON.stringify`). We get a similar memory savings when reading the file back in at startup.

This isn't ideal yet. What we really want is to store everything in a LevelDB-style database, and keep 0x copies in memory (modulo the read cache that the kernel maintains, which could maybe go away). But the only LevelDB bindings I've found so far are async, and the kernel needs synchronous reads from the stored state data.

refs #65 but doesn't close it because we're still keeping full state in RAM all the time
