### PR TITLE
Simplify Timer creation

### DIFF
--- a/lib/ag-solo/vats/bootstrap.js
+++ b/lib/ag-solo/vats/bootstrap.js
@@ -1,8 +1,8 @@
 import harden from '@agoric/harden';
-import {allComparable} from '@agoric/ertp/util/sameStructure';
+import { allComparable } from '@agoric/ertp/util/sameStructure';
 // this will return { undefined } until `ag-solo set-gci-ingress`
 // has been run to update gci.js
-import {GCI} from './gci';
+import { GCI } from './gci';
 
 console.log(`loading bootstrap.js`);
 

--- a/lib/ag-solo/vats/bootstrap.js
+++ b/lib/ag-solo/vats/bootstrap.js
@@ -1,8 +1,8 @@
 import harden from '@agoric/harden';
-import { allComparable } from '@agoric/ertp/util/sameStructure';
+import {allComparable} from '@agoric/ertp/util/sameStructure';
 // this will return { undefined } until `ag-solo set-gci-ingress`
 // has been run to update gci.js
-import { GCI } from './gci';
+import {GCI} from './gci';
 
 console.log(`loading bootstrap.js`);
 
@@ -56,11 +56,6 @@ export default function setup(syscall, state, helpers) {
         await E(walletVat).setPresences();
       }
 
-      async function addTimerService(timerDevice, timerVat) {
-        E(timerVat).registerTimerDevice(timerDevice);
-        return E(timerVat).createTimerService();
-      }
-
       // Make services that are provided on the real or virtual chain side
       async function makeChainBundler(vats, timerDevice) {
         // Remember the assayIds to pass to the wallet
@@ -83,9 +78,8 @@ export default function setup(syscall, state, helpers) {
         // Create singleton instances.
         const sharingService = await E(vats.sharing).getSharingService();
         const registrar = await E(vats.registrar).getSharedRegistrar();
-        const chainTimerService = await addTimerService(
+        const chainTimerService = await E(vats.timer).createTimerService(
           timerDevice,
-          vats.timer,
         );
         const zoe = await E(vats.zoe).getZoe();
         const contractHost = await E(vats.host).makeHost();
@@ -265,9 +259,8 @@ export default function setup(syscall, state, helpers) {
               await setupCommandDevice(vats.http, devices.command, {
                 client: true,
               });
-              const localTimerService = await addTimerService(
+              const localTimerService = await E(vats.timer).createTimerService(
                 devices.timer,
-                vats.timer,
               );
               await addRemote(GCI);
               // addEgress(..., index, ...) is called in vat-provisioning.
@@ -313,9 +306,8 @@ export default function setup(syscall, state, helpers) {
               await setupCommandDevice(vats.http, devices.command, {
                 client: true,
               });
-              const localTimerService = await addTimerService(
+              const localTimerService = await E(vats.timer).createTimerService(
                 devices.timer,
-                vats.timer,
               );
               await addRemote(GCI);
               // addEgress(..., PROVISIONER_INDEX) is called in case two_chain


### PR DESCRIPTION
Combine `registerTimerDevice(timerDevice)` and `createTimerService()` into one call `createTimerService(timerDevice)` 

